### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -1,6 +1,6 @@
 # BDKGeometry
 
-A set of helper functions I've been using in various XCode projects, abstracted for great good!
+A set of helper functions I've been using in various Xcode projects, abstracted for great good!
 
 ## Getting started
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
